### PR TITLE
Consolidating PRS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.swp
+/python/venv/
+/python/__pycache__/
+.DS_Store

--- a/downloadFlowEntities.sh
+++ b/downloadFlowEntities.sh
@@ -70,7 +70,7 @@ function downloadZipFile {
                   --no-progress-meter                     \
                   > "${outputFile}" ; then
         if [ -r "${outputFile}" ] ; then
-            unzip "${outputFile}" -d "./src/main/${outputDirectory}/" > /dev/null || true
+            unzip -o "${outputFile}" -d "./src/main/${outputDirectory}/" > /dev/null || true
             rm "${outputFile}"
             # Use jq to format the JSON files that were in the zip file.
             while IFS= read -r -d '' jsonFile ; do

--- a/downloadFlowEntities.sh
+++ b/downloadFlowEntities.sh
@@ -85,7 +85,7 @@ function downloadZipFile {
 #                Flow Route            Directory        Query String Parameters
 #                -------------------   ------------     ---------------------------
 downloadJsonFile flows                 flows
-downloadJsonFile sharedConfig          sharedConfig     '?encrypted=true'
+downloadJsonFile sharedConfig          sharedConfig     '?encrypted_only=true'
 downloadJsonFile flowTriggerers        triggerers
 downloadJsonFile patchSets             patchSets
 downloadZipFile  resourceCollections   flowResources


### PR DESCRIPTION
- Use `encrypted_only` query string parameter instead of `encrypted`.
- No longer prompts user to overwrite files when unzipping resources.  Not overwriting one or more files could lead to inconsistencies.  Overwritten files can be restored via version control if necessary.