### PR TITLE
Reload recipe script

### DIFF
--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+echo "Run this script from the same directory as your recipe metadata.json"
+echo "Provide an environment shortname which is at least Flow V5.11."
+case $# in
+  1)
+    ENV="$1"
+    ;;
+  0)
+    ENV="local"
+    ;;
+  *)
+    return 1
+    ;;
+esac
+RECIPE_FAMILY=$(basename "`pwd`")
+RECIPE=$(jq -r ".id" metadata.json)
+echo "Refreshing ${RECIPE_FAMILY} - ${RECIPE}"
+pushd ..
+  uploadRecipe.sh "$RECIPE_FAMILY" "$ENV"
+popd
+source setEnvForUpload.sh "$ENV"
+echo "Rerunning previous answers.  If they're incomplete, this will error and you need to go answer them in the interface and rerun this."
+PREVIOUS_RUN=$(curl $CURL_ARGS -s -H "flow-token: $FLOW_TOKEN" "$HOST/repository/auditLogs?type=recipeExecution&limit=1" )
+ID=$(jq -r ".[0] | .audited.id" <<< "$PREVIOUS_RUN")
+
+if [ "$ID" = "$RECIPE" ]; then
+  PREVIOUS_ANSWERS=$(jq -r ".[0] | .audited.input" <<< "$PREVIOUS_RUN")
+  curl $CURL_ARGS -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/repository/recipes/$RECIPE/execute?forceInstallAll=true" --data-binary "$PREVIOUS_ANSWERS"
+else
+  echo "Last recipe execution: " $ID "Attempted recipe execution: " $RECIPE "rerun through Recipe History" 
+fi

--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
-echo "Run this script from the same directory as your recipe metadata.json"
-echo "Provide an environment shortname which is at least Flow V5.11."
-echo "The first parameter must either be the environment shortname or an integer greater than 0 (the number of days to regard as 'recent' when fetching recent recipeExecutions, defaults to 1 day if not supplied)"
+echo "To provide an environment, use -e followed by an environment shortname. The default environment is local.\nTarget environments must be at least Flow V5.11."
 # Takes in up to three parameters: 
 #   - environment ENV, defaults to 'local'
 #   - number of days to fetch recipeExecutions for RECENT, defaults to 1
@@ -26,26 +24,35 @@ if [ -z "$RECENT" ]; then RECENT=1; fi
 if ! [[ $RECENT =~ ^[0-9]+$ && $RECENT -gt 0 ]]; then echo "Days parameter, if provided, must be an integer greater than 0"; exit; fi
 
 RECIPE_FAMILY=$(basename "`pwd`")
+if [ ! -r "./metadata.json" ] ; then
+   echo "\nError: no metadata.json found.\nRun this script from the same directory as your recipe metadata.json"
+   exit 1
+fi
 RECIPE=$(jq -r ".id" metadata.json)
 echo "Refreshing ${RECIPE_FAMILY} - ${RECIPE}"
-pushd ..
+
+source setEnvForUpload.sh "$ENV" || exit $?
+pushd .. > /dev/null
  uploadRecipe.sh "$RECIPE_FAMILY" "$ENV"
-popd
-source setEnvForUpload.sh "$ENV"
+popd > /dev/null
+
 NOW=$(date +%s000)
 DAY=$(expr 1000 \* 60 \* 60 \* 24 \* $RECENT)
 YESTERDAY=$(expr $NOW - $DAY)
 RECENT_RECIPE_EXECUTIONS=$(curl $CURL_ARGS -s -H "flow-token: $FLOW_TOKEN" "$HOST/repository/auditLogs?type=recipeExecution&start=$YESTERDAY&end=$NOW" )
 HOURS=$(expr 24 \* $RECENT)
 
-if ! [ $RECIPEUSER = 'none' ]; then
+if [ -z "$RECENT_RECIPE_EXECUTIONS" ]; then echo "No recent recipe executions found on this server";exit; fi
+
+if ! [ "$RECIPEUSER" = 'none' ]; then
   PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'" and .userName=="'"$RECIPEUSER"'" )][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
 else
   PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'")][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
 fi
 
-if [ $PREVIOUS_ANSWERS = 'null' ]; then
-  if ! [ $RECIPEUSER = 'none' ]; then
+
+if [ "$PREVIOUS_ANSWERS" = 'null' ]; then
+  if ! [ "$RECIPEUSER" = 'none' ]; then
     echo "No recipe executions by user:" $RECIPEUSER "found on server:" $ENV "for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."
   else
     echo "No recipe executions found on server:" $ENV "for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."

--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -2,65 +2,28 @@
 echo "Run this script from the same directory as your recipe metadata.json"
 echo "Provide an environment shortname which is at least Flow V5.11."
 echo "The first parameter must either be the environment shortname or an integer greater than 0 (the number of days to regard as 'recent' when fetching recent recipeExecutions, defaults to 1 day if not supplied)"
-# Takes in up to three parameters: environment ENV, number of days to fetch recipeExecutions for RECENT, a username to use to filter recipeExecutions RECIPEUSER
-# Accepted combinations:
-#  ENV RECENT RECIPEUSER
-#  ENV RECENT
-#  RECENT RECIPEUSER
-#  RECENT
-#  ENV
-# Where the first parameter supplied is an integer, ENV defaults to 'local'
-# Where no RECENT parameter is supplied, RECENT defaults to 1 day
+# Takes in up to three parameters: 
+#   - environment ENV, defaults to 'local'
+#   - number of days to fetch recipeExecutions for RECENT, defaults to 1
+#   - a username to use to filter recipeExecutions RECIPEUSER
+# Use the following flags to include each parameter:
+#  ENV: -e
+#  RECENT: -d
+#  RECIPEUSER: -u
+ENV='local'
 RECIPEUSER='none'
-RECENT=0
-case $# in
-  3)
-    ENV=$1
-    if ! [[ $2 =~ ^[0-9]+$ && $2 -gt 0 ]]; then
-      echo "Second parameter must be an integer greater than 0"
-      exit
-    else 
-      RECENT=$2
-    fi
-    RECIPEUSER=$3
-    ;;
-  2)
-    if [[ $1 =~ ^[0-9]+$ ]]; then
-      echo "Integer input as first parameter, defaulting to local environment"
-      RECENT=$1
-      RECIPEUSER=$2
-      ENV="local"
-    else
-      ENV="$1"
-      if ! [[ $2 =~ ^[0-9]+$ && $2 -gt 0 ]]; then
-        echo "Days parameter, if provided, must be an integer greater than 0"
-        exit
-      else
-        RECENT=$2
-      fi
-    fi
-    ;;
-  1)
-    if [[ $1 =~ ^[0-9]+$ && $1 -gt 0 ]]; then
-      echo "Integer input as first parameter, defaulting to local environment"
-      RECENT=$1
-      ENV="local"
-    else
-      ENV="$1"
-    fi
-    ;;
-  0)
-    ENV="local"
-    ;;
-  *)
-    return 1
-    ;;
-esac
 
-if ! [[ $RECENT -gt 0 ]]; then
-  echo "No input specified for RECENT, defaulting to 1 day"
-  RECENT=1
-fi
+while getopts d:u:e: flag
+do
+  case "${flag}" in
+    d) RECENT=${OPTARG};;
+    u) RECIPEUSER=${OPTARG};;
+    e) ENV=${OPTARG};;
+  esac
+done
+
+if [ -z "$RECENT" ]; then RECENT=1; fi
+if ! [[ $RECENT =~ ^[0-9]+$ && $RECENT -gt 0 ]]; then echo "Days parameter, if provided, must be an integer greater than 0"; exit; fi
 
 RECIPE_FAMILY=$(basename "`pwd`")
 RECIPE=$(jq -r ".id" metadata.json)

--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -1,14 +1,53 @@
 #!/bin/sh
 echo "Run this script from the same directory as your recipe metadata.json"
 echo "Provide an environment shortname which is at least Flow V5.11."
+echo "The first parameter must either be the environment shortname or an integer greater than 0 (the number of days to regard as 'recent' when fetching recent recipeExecutions, defaults to 1 day if not supplied)"
+# Takes in up to three parameters: environment ENV, number of days to fetch recipeExecutions for RECENT, a username to use to filter recipeExecutions RECIPEUSER
+# Accepted combinations:
+#  ENV RECENT RECIPEUSER
+#  ENV RECENT
+#  RECENT RECIPEUSER
+#  RECENT
+#  ENV
+# Where the first parameter supplied is an integer, ENV defaults to 'local'
+# Where no RECENT parameter is supplied, RECENT defaults to 1 day
+RECIPEUSER='none'
 RECENT=0
 case $# in
+  3)
+    ENV=$1
+    if ! [[ $2 =~ ^[0-9]+$ && $2 -gt 0 ]]; then
+      echo "Second parameter must be an integer greater than 0"
+      exit
+    else 
+      RECENT=$2
+    fi
+    RECIPEUSER=$3
+    ;;
   2)
-    ENV="$1"
-    RECENT="$2"
+    if [[ $1 =~ ^[0-9]+$ ]]; then
+      echo "Integer input as first parameter, defaulting to local environment"
+      RECENT=$1
+      RECIPEUSER=$2
+      ENV="local"
+    else
+      ENV="$1"
+      if ! [[ $2 =~ ^[0-9]+$ && $2 -gt 0 ]]; then
+        echo "Days parameter, if provided, must be an integer greater than 0"
+        exit
+      else
+        RECENT=$2
+      fi
+    fi
     ;;
   1)
-    ENV="$1"
+    if [[ $1 =~ ^[0-9]+$ && $1 -gt 0 ]]; then
+      echo "Integer input as first parameter, defaulting to local environment"
+      RECENT=$1
+      ENV="local"
+    else
+      ENV="$1"
+    fi
     ;;
   0)
     ENV="local"
@@ -18,19 +57,8 @@ case $# in
     ;;
 esac
 
-if ! [[ $RECENT =~ ^[0-9]+$ ]]; then
- echo "Second parameter, if provided, must be an integer greater than 0"
- exit
-fi
-
-if [[ $ENV =~ ^[0-9]+$ ]]; then
-  echo "Integer input as first parameter, defaulting to local environment"
-  RECENT=$ENV
-  ENV="local"
-fi
-
 if ! [[ $RECENT -gt 0 ]]; then
-  echo "No valid input for RECENT, defaulting to 1 day"
+  echo "No input specified for RECENT, defaulting to 1 day"
   RECENT=1
 fi
 
@@ -46,9 +74,19 @@ DAY=$(expr 1000 \* 60 \* 60 \* 24 \* $RECENT)
 YESTERDAY=$(expr $NOW - $DAY)
 RECENT_RECIPE_EXECUTIONS=$(curl $CURL_ARGS -s -H "flow-token: $FLOW_TOKEN" "$HOST/repository/auditLogs?type=recipeExecution&start=$YESTERDAY&end=$NOW" )
 HOURS=$(expr 24 \* $RECENT)
-PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'")][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
+
+if ! [ $RECIPEUSER = 'none' ]; then
+  PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'" and .userName=="'$RECIPEUSER'" )][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
+else
+  PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'")][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
+fi
+
 if [ $PREVIOUS_ANSWERS = 'null' ]; then
-  echo "No recipe executions found on this server for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."
+  if ! [ $RECIPEUSER = 'none' ]; then
+    echo "No recipe executions by user:" $RECIPEUSER "found on server:" $ENV "for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."
+  else
+    echo "No recipe executions found on server:" $ENV "for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."
+  fi
 else
   echo "Rerunning previous answers.  If they're incomplete, this will error and you need to go answer them in the interface and rerun this."
   curl $CURL_ARGS -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/repository/recipes/$RECIPE/execute?forceInstallAll=true" --data-binary "$PREVIOUS_ANSWERS"

--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 echo "Run this script from the same directory as your recipe metadata.json"
 echo "Provide an environment shortname which is at least Flow V5.11."
+RECENT=0
 case $# in
+  2)
+    ENV="$1"
+    RECENT="$2"
+    ;;
   1)
     ENV="$1"
     ;;
@@ -12,6 +17,23 @@ case $# in
     return 1
     ;;
 esac
+
+if ! [[ $RECENT =~ ^[0-9]+$ ]]; then
+ echo "Second parameter, if provided, must be an integer greater than 0"
+ exit
+fi
+
+if [[ $ENV =~ ^[0-9]+$ ]]; then
+  echo "Integer input as first parameter, defaulting to local environment"
+  RECENT=$ENV
+  ENV="local"
+fi
+
+if ! [[ $RECENT -gt 0 ]]; then
+  echo "No valid input for RECENT, defaulting to 1 day"
+  RECENT=1
+fi
+
 RECIPE_FAMILY=$(basename "`pwd`")
 RECIPE=$(jq -r ".id" metadata.json)
 echo "Refreshing ${RECIPE_FAMILY} - ${RECIPE}"
@@ -20,21 +42,24 @@ pushd ..
 popd
 source setEnvForUpload.sh "$ENV"
 NOW=$(date +%s000)
-DAY=$(expr 1000 \* 60 \* 60 \* 24)
+DAY=$(expr 1000 \* 60 \* 60 \* 24 \* $RECENT)
 YESTERDAY=$(expr $NOW - $DAY)
 RECENT_RECIPE_EXECUTIONS=$(curl $CURL_ARGS -s -H "flow-token: $FLOW_TOKEN" "$HOST/repository/auditLogs?type=recipeExecution&start=$YESTERDAY&end=$NOW" )
 INDEX=0
 LENGTH=$(jq -r ". | length" <<< "$RECENT_RECIPE_EXECUTIONS")
 for i in $(jq -r ".[] | .audited.id" <<< "$RECENT_RECIPE_EXECUTIONS"); do
- INDEX=$(expr $INDEX + 1)
  if [ "$i" = "$RECIPE" ]; then
     echo "Recent execution of " $i "found at index" $INDEX
     break
  fi
+ INDEX=$(expr $INDEX + 1)
 done
 
+HOURS=$(expr 24 \* $RECENT)
+echo "index" $INDEX
+echo "length" $LENGTH
 if [ $INDEX -ge $LENGTH ]; then
-  echo "No recipe executions found on this server for" $RECIPE "in last 24 hours. Rerun through Recipe History."
+  echo "No recipe executions found on this server for" $RECIPE "in last" $HOURS "hours. Rerun through Recipe History."
 else
   echo "Rerunning previous answers.  If they're incomplete, this will error and you need to go answer them in the interface and rerun this."
   PREVIOUS_ANSWERS=$(jq -r ".[$INDEX] | .audited.input" <<< "$RECENT_RECIPE_EXECUTIONS")

--- a/reloadRecipe.sh
+++ b/reloadRecipe.sh
@@ -39,7 +39,7 @@ RECENT_RECIPE_EXECUTIONS=$(curl $CURL_ARGS -s -H "flow-token: $FLOW_TOKEN" "$HOS
 HOURS=$(expr 24 \* $RECENT)
 
 if ! [ $RECIPEUSER = 'none' ]; then
-  PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'" and .userName=="'$RECIPEUSER'" )][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
+  PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'" and .userName=="'"$RECIPEUSER"'" )][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
 else
   PREVIOUS_ANSWERS=$(jq -r '[.[] | select(.audited.id=="'$RECIPE'")][0] | .audited.input' <<< "$RECENT_RECIPE_EXECUTIONS")
 fi


### PR DESCRIPTION
This is an expansion on the script written by @davidhagan and @ChrisHagan that allows updates to recipes to be uploaded and executed with a set of previous answers from recipe history, intentionally bypassing conflict detection by using forceInstallAll=true

Current behaviour:
- It now checks for the most recent recipe execution with the same id as the recipe being uploaded, and only attempts to re-run it if the ids match.
- By default, it only fetches recipeExecutions for the last 24 hours.
- The timeframe can be specified/extended by supplying an integer, representing the number of days, as either the first or second parameter (ENV defaults to local environment if the first parameter is an integer, otherwise it still uses the first parameter for environment)
- Recipe executions can be further filtered by supplying a specific username.


