### PR TITLE
Batch Upload Resource Collections

### DIFF
--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -20,8 +20,6 @@ for dir in ./*; do
     fi
 done
 
-cd ../../..
-
 if [ -n "$errorReport" ]; then
     echo -e "Some resources failed to upload:\n$errorReport"
 else

--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
-# This bash script is used to batch upload resource collections to the iHub server. It iterates through 
+# This bash script is used to batch upload resource collections to the iHub server. It iterates through  the directories in the src/main/flowResources directory and uploads each resource collection to the server.
 
 # Assumes that you are in the root of the community directory and that it's named like /ihub-community-<COMMUNITY_NAME>
 community=$(basename "$(pwd)" | grep -o '[^-]*$') 
 
 cd ./src/main/flowResources || exit
 
+errorReport=""
 for dir in ./*; do
     if [ -d "$dir" ]; then
         resource=$(basename $dir)
         echo ""
         echo "Uploading collection $resource"
-        uploadResourceCollection.sh "$resource" "$community"
+        response=$(uploadResourceCollection.sh "$resource" "$community")
         echo ""
+
+        if [ "$response" -eq 1 ]; then
+            errorReport+="$resource failed to upload.\n"
+        fi    
     fi
 done
 
-echo "Resource collections uploaded successfully!"
+
+
+if [ -n "$errorReport" ]; then
+    echo -e "Some resources failed to upload:\n$errorReport"
+else
+    echo "All resource collections uploaded successfully!"
+fi

--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -10,9 +10,9 @@ cd ./src/main/flowResources || exit
 errorReport=""
 for dir in ./*; do
     if [ -d "$dir" ]; then
-        resource=$(basename $dir)
         echo -e "\nUploading collection $resource\n"
   
+        resource=$(basename $dir)
         if ! uploadResourceCollection.sh "$resource" "$community" ; then
             errorReport+="$resource failed to upload.\n"
         fi

--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -11,14 +11,12 @@ errorReport=""
 for dir in ./*; do
     if [ -d "$dir" ]; then
         resource=$(basename $dir)
-        echo ""
-        echo "Uploading collection $resource"
-        response=$(uploadResourceCollection.sh "$resource" "$community")
-        echo ""
-
-        if [ "$response" -eq 1 ]; then
+        echo -e "\nUploading collection $resource\n"
+  
+        if ! uploadResourceCollection.sh "$resource" "$community" ; then
             errorReport+="$resource failed to upload.\n"
-        fi    
+        fi
+
     fi
 done
 

--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -20,7 +20,7 @@ for dir in ./*; do
     fi
 done
 
-
+cd ../../..
 
 if [ -n "$errorReport" ]; then
     echo -e "Some resources failed to upload:\n$errorReport"

--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This bash script is used to batch upload resource collections to the iHub server. It iterates through 
+
+# Assumes that you are in the root of the community directory and that it's named like /ihub-community-<COMMUNITY_NAME>
+community=$(basename "$(pwd)" | grep -o '[^-]*$') 
+
+cd ./src/main/flowResources || exit
+
+for dir in ./*; do
+    if [ -d "$dir" ]; then
+        resource=$(basename $dir)
+        echo ""
+        echo "Uploading collection $resource"
+        uploadResourceCollection.sh "$resource" "$community"
+        echo ""
+    fi
+done
+
+echo "Resource collections uploaded successfully!"

--- a/uploadResourceCollection.sh
+++ b/uploadResourceCollection.sh
@@ -35,6 +35,8 @@ then
   else
     echo "Got unexpected HTTP response ${http_response}. This is likely an error."
   fi
+
+  return 1
 else
   cat uploadResourceCollectionResponse.txt
 fi


### PR DESCRIPTION
During URL cutovers, one minor bottle neck is the updating of flow Resources. This PR provides a convenience script which enables the user to re-upload every community resource defined for a given school. It iterates through all of the school's resource collections, calling the already-defined `uploadResourceCollection.sh` script

Two things worth mentioning:
- This script assumes that you've added `ihub-developer-scripts` to path
- This script doesn't discriminate between QA and Production environments. I have yet to see a community repo which distinguishes between the two envs for flow resources, so I'm open to feedback about how this conditionality could be applied.