### PR TITLE
fix downloadFlowEntities Success Check

### DIFF
--- a/downloadFlowEntities.sh
+++ b/downloadFlowEntities.sh
@@ -40,18 +40,19 @@ function downloadJsonFile {
     outputDirectory=${2:-$1}
     parameters=${3:-}
     output=$(curl $CURL_ARGS "${HOST}/repository/${entityType}${parameters}" \
-                -w "\nStatus: %{http_code}"                       \
+                -w "\nFLOW_RESPONSE_STATUS: %{http_code}"                       \
                 -H "flow-token: ${FLOW_TOKEN}"                    \
                 -H "Accept: application/json"                     \
                 --no-progress-meter)
 
-    if [[ "${output}" =~ "Status: 200" ]] ; then
+    if [[ "${output}" =~ "FLOW_RESPONSE_STATUS: 200" ]] ; then
         outputFile="./src/main/${outputDirectory}/${environment}.json"
-        if echo "${output}" | grep -v "Status: "| jq empty >& /dev/null ; then
-            echo "${output}" | grep -v "Status: " > "${outputFile}"
+        if echo "${output}" | grep -v "FLOW_RESPONSE_STATUS: "| jq empty >& /dev/null ; then
+            echo "${output}" | grep -v "FLOW_RESPONSE_STATUS: " > "${outputFile}"
             filtered=$(jq 'del(.[].metadata, .[].referencedBy)' "${outputFile}")
             echo "${filtered}" > "${outputFile}"
         else
+            echo "${output}"
             >&2 echo "server did not return valid JSON.  Is your token valid?"
             return 1
         fi


### PR DESCRIPTION
This change was the result of some errors being thrown in the initial implementation. When going through a URL cutover for CUW, `downloadFlowEntities.sh` would throw the error: 
```sh
server did not return valid JSON.  Is your token valid?
```
, despite the fact that we validated both the flow token and url referenced from the `creds` directory were correct. Changing which portion of the string we validated against resolved the issue. 

This change ought to be credited to @timjstewart1024's suggestion, as he ran into these issues during his tenure covering me during the first week of July.