### PR TITLE
Update "uploadRecipe.sh" - add child recipes

### DIFF
--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -10,34 +10,66 @@ case $# in
     ENVIRONMENT="local"
     ;;
   *)
-    echo "not enough arguments supplied.  You must supply the recipeDirectory to this command."
-    return 1
+    echo "Not enough arguments supplied. You must supply the recipe directory."
+    exit 1
     ;;
 esac    
 
-source setEnvForUpload.sh $ENVIRONMENT
+source setEnvForUpload.sh "$ENVIRONMENT"
 
-[ -e "${FLOW}.zip" ] && rm ${FLOW}.zip
-zip -r ${FLOW}.zip $FLOW
+declare -A PROCESSED_RECIPES
 
-if [ -z $FLOW_TOKEN ] ;
-then
-	return 1
-else
-	http_response=$(curl $CURL_ARGS -s -o uploadRecipeResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${FLOW}" "$HOST/repository/recipes" --data-binary "@${FLOW}.zip")
-fi
+zip_and_upload() {
+  echo $PROCESSED_RECIPES
+  local RECIPE="$1"
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
+  # Prevent reprocessing
+  # if [ "${PROCESSED_RECIPES[$RECIPE]}" ]; then
+  #   return
+  # fi
+  # PROCESSED_RECIPES[$RECIPE]=1
+
+  if [ ! -d "$RECIPE" ]; then
+    echo "Recipe directory $RECIPE does not exist, skipping..."
+    return
   fi
-else
-  cat uploadRecipeResponse.txt
-fi
 
-[ -e uploadRecipeResponse.txt ] && rm uploadRecipeResponse.txt
-rm ${FLOW}.zip
+  echo "Zipping and uploading: $RECIPE"
+  [ -e "${RECIPE}.zip" ] && rm "${RECIPE}.zip"
+  zip -r "${RECIPE}.zip" "$RECIPE"
+
+  if [ -z "$FLOW_TOKEN" ]; then
+    echo "FLOW_TOKEN is not set. Exiting."
+    exit 1
+  fi
+
+  http_response=$(curl $CURL_ARGS -s -o uploadRecipeResponse.txt -w "%{http_code}" -X POST \
+    -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" \
+    -H "format: zip" -H "name: ${RECIPE}" "$HOST/repository/recipes" \
+    --data-binary "@${RECIPE}.zip")
+
+  echo "${HOST}"
+
+  if [ "$http_response" != "200" ]; then
+    if [ "$http_response" = "302" ]; then
+      echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
+    else
+      echo "Got unexpected HTTP response ${http_response}. This is likely an error."
+    fi
+  else
+    cat uploadRecipeResponse.txt
+  fi
+
+  [ -e uploadRecipeResponse.txt ]
+
+  METADATA_FILE="${RECIPE}/metadata.json"
+  if [ -f "$METADATA_FILE" ]; then
+    local child_recipes=$(jq -r '.bindings | to_entries[] | select(.value.variableType == "recipeExecution") | .value.recipeId' "$METADATA_FILE" | sort -u)
+    
+    for child_recipe in $child_recipes; do
+      zip_and_upload "$child_recipe"
+    done
+  fi
+}
+
+zip_and_upload "$FLOW"

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -8,14 +8,22 @@ ENVIRONMENT="$2"
 
 
 case $# in
-  2|3)
+  1)
+    ENVIRONMENT="local"
+    ;;
+  2)
+    if [ "$2" = "--include-child-recipes" ]; then
+      ENVIRONMENT="local"
+      INCLUDE_CHILD=true
+    else
+      ENVIRONMENT="$2"
+    fi
+    ;;
+  3)
     ENVIRONMENT="$2"
     if [ "$3" = "--include-child-recipes" ]; then
       INCLUDE_CHILD=true
     fi
-    ;;
-  1)
-    ENVIRONMENT="local"
     ;;
   *)
     echo "Not enough arguments supplied. You must supply the recipe directory."
@@ -23,18 +31,13 @@ case $# in
     ;;
 esac
 
+
 source setEnvForUpload.sh "$ENVIRONMENT"
 
 declare -A PROCESSED_RECIPES
 
 zip_and_upload() {
   local RECIPE="$1"
-
-  # Prevent reprocessing
-  # if [ "${PROCESSED_RECIPES[$RECIPE]}" ]; then
-  #   return
-  # fi
-  # PROCESSED_RECIPES[$RECIPE]=1
 
   if [ ! -d "$RECIPE" ]; then
     echo "Recipe directory $RECIPE does not exist, skipping..."

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -34,8 +34,6 @@ esac
 
 source setEnvForUpload.sh "$ENVIRONMENT"
 
-declare -A PROCESSED_RECIPES
-
 zip_and_upload() {
   local RECIPE="$1"
 


### PR DESCRIPTION
Updated the `uploadRecipe.sh` command to account for metarecipes. On @timjstewart1024 's advice, made this a flag instead of changing the default behavior of `uploadRecipe`.

Background:
- When uploading User Provisioning Version 5, I had to also upload all child recipes. @amlane explained that these were just in the `metadata.json` file, so this script reads that file and, if it finds any child recipes, goes and uploads them recursively. 

I don't love my definition of `case $# in` here (please feel free to correct / update) but I was trying to match the current functionality that allows you to pass (or not pass) environment, and this way of doing it preserves the ability to run any of the following (all still working now):

1. `uploadRecipe.sh one_step_user_provisioning_basic_5_0_0` - still defaults to local
2. `uploadRecipe.sh one_step_user_provisioning_basic_5_0_0 {env}`
3. `uploadRecipe.sh one_step_user_provisioning_basic_5_0_0 {env} --include-child-recipes`
