### PR TITLE
Enable Batch Resource Upload to QA

### DIFF
--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -3,7 +3,18 @@
 # This bash script is used to batch upload resource collections to the iHub server. It iterates through  the directories in the src/main/flowResources directory and uploads each resource collection to the server.
 
 # Assumes that you are in the root of the community directory and that it's named like /ihub-community-<COMMUNITY_NAME>
-community=$(basename "$(pwd)" | grep -o '[^-]*$') 
+. "$(dirname "$0")/commonFunctions.sh"
+
+[[ -z "$1" ]] && die "Usage: $0 <production|qa>"
+environment="$1"
+
+
+environmentPrefix=""
+if [ "$environment" == "qa" ]; then
+    environmentPrefix="qa-"
+fi
+
+community="${environmentPrefix}$(basename "$(pwd)" | grep -o '[^-]*$')"
 
 cd ./src/main/flowResources || exit
 


### PR DESCRIPTION
Unticketed; `batchUploadResourceCollections.sh` was previously only equipped for uploads to production. By specifying an `env` (`qa` | `production`) via the command line args, we can extend the functionality to QA, too. This is beneficial for cases where schools want to copy their resources from prod into QA.