### PR TITLE
Add support for batch uploading resource collections to qa instances

### DIFF
--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -3,7 +3,8 @@
 # This bash script is used to batch upload resource collections to the iHub server. It iterates through  the directories in the src/main/flowResources directory and uploads each resource collection to the server.
 
 # Assumes that you are in the root of the community directory and that it's named like /ihub-community-<COMMUNITY_NAME>
-community=$(basename "$(pwd)" | grep -o '[^-]*$') 
+# community=$(basename "$(pwd)" | grep -o '[^-]*$') 
+community=$(basename "$(pwd)" | awk -F "ihub-community-" '{print $2}')
 
 cd ./src/main/flowResources || exit
 


### PR DESCRIPTION
The current batch upload script assumes a direct pull from ihub-community, but it can be useful to be able to change a pulled directory to the QA version to copy resources over to QA for a customer, this splits on the ihub-community- part of the path instead of the final dash for better flexibility 