### PR TITLE
FLOW-2734 | Insert min/max versions in metadata before recipe upload

### DIFF
--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -35,16 +35,14 @@ if [ -f "${FLOW}/metadata.json" ]; then
       NEW_ID="${ID_VALUE}_${VERSION_FORMATTED}"
 
       # Update the metadata.json file with the new ID
-      sed "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json"
-
+      sed "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json" > "${FLOW}/metadata.json.tmp" && mv "${FLOW}/metadata.json.tmp" "${FLOW}/metadata.json"
       echo "Updated ID from '$ID_VALUE' to '$NEW_ID' in metadata.json"
     fi
   fi
-  # Insert min and max version props
-  MIN_VERSION="1.0.0"
-  MAX_VERSION="100.0.0"
-  sed '1s/{/{"minVersion":"'$MIN_VERSION'","maxVersion":"'$MAX_VERSION'",/' "${FLOW}/metadata.json"
-  echo "Updated minVersion to '$MIN_VERSION' and maxVersion to '$MAX_VERSION' in metadata.json"
+  # insert "minVersion": "1.0.0" and "maxVersion": "100.0.0" if both are not provided
+  if ! grep -q '"minVersion"[[:space:]]*:' "${FLOW}/metadata.json" && ! grep -q '"maxVersion"[[:space:]]*:' "${FLOW}/metadata.json"; then
+    sed '1s/{/{"minVersion":"1.0.0","maxVersion":"100.0.0",/' "${FLOW}/metadata.json" > "${FLOW}/metadata.json.tmp" && mv "${FLOW}/metadata.json.tmp" "${FLOW}/metadata.json"
+  fi
 fi
 
 source setEnvForUpload.sh $ENVIRONMENT

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -16,32 +16,42 @@ esac
 
 # Check if metadata.json exists in the directory
 if [ -f "${FLOW}/metadata.json" ]; then
+  # Backup metadata.json
+  cp "${FLOW}/metadata.json" "${FLOW}/metadata.json.bak"
+
   # Extract the id value from metadata.json
   ID_VALUE=$(grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' "${FLOW}/metadata.json" | cut -d'"' -f4)
-  
+
   # Check if the ID ends with a semantic version pattern (digits separated by underscores)
   if ! echo "$ID_VALUE" | grep -q '_[0-9]\+_[0-9]\+_[0-9]\+$'; then
     # ID doesn't end with version, so look for the version key
     VERSION_VALUE=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "${FLOW}/metadata.json" | cut -d'"' -f4)
-    
+
     if [ -n "$VERSION_VALUE" ]; then
       # Replace dots with underscores in the version
       VERSION_FORMATTED=$(echo "$VERSION_VALUE" | tr '.' '_')
-      
+
       # Create the new ID by appending the formatted version
       NEW_ID="${ID_VALUE}_${VERSION_FORMATTED}"
-      
+
       # Update the metadata.json file with the new ID
-      sed -i "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json"
-      
+      sed -i '' "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json"
+
       echo "Updated ID from '$ID_VALUE' to '$NEW_ID' in metadata.json"
     fi
   fi
+  # Insert min and max version props
+  MIN_VERSION="1.0.0"
+  MAX_VERSION="100.0.0"
+  sed -i '' '1s/{/{"minVersion":"'$MIN_VERSION'","maxVersion":"'$MAX_VERSION'",/' "${FLOW}/metadata.json"
+  echo "Updated minVersion to '$MIN_VERSION' and maxVersion to '$MAX_VERSION' in metadata.json"
 fi
 
 source setEnvForUpload.sh $ENVIRONMENT
 [ -e "${FLOW}.zip" ] && rm ${FLOW}.zip
 zip -r ${FLOW}.zip $FLOW
+# Restore metadata.json from backup
+[ -f "${FLOW}/metadata.json.bak" ] && mv "${FLOW}/metadata.json.bak" "${FLOW}/metadata.json"
 if [ -z $FLOW_TOKEN ] ;
 then
 	return 1

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -35,7 +35,7 @@ if [ -f "${FLOW}/metadata.json" ]; then
       NEW_ID="${ID_VALUE}_${VERSION_FORMATTED}"
 
       # Update the metadata.json file with the new ID
-      sed -i '' "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json"
+      sed "s/\"id\"[[:space:]]*:[[:space:]]*\"$ID_VALUE\"/\"id\": \"$NEW_ID\"/" "${FLOW}/metadata.json"
 
       echo "Updated ID from '$ID_VALUE' to '$NEW_ID' in metadata.json"
     fi
@@ -43,15 +43,13 @@ if [ -f "${FLOW}/metadata.json" ]; then
   # Insert min and max version props
   MIN_VERSION="1.0.0"
   MAX_VERSION="100.0.0"
-  sed -i '' '1s/{/{"minVersion":"'$MIN_VERSION'","maxVersion":"'$MAX_VERSION'",/' "${FLOW}/metadata.json"
+  sed '1s/{/{"minVersion":"'$MIN_VERSION'","maxVersion":"'$MAX_VERSION'",/' "${FLOW}/metadata.json"
   echo "Updated minVersion to '$MIN_VERSION' and maxVersion to '$MAX_VERSION' in metadata.json"
 fi
 
 source setEnvForUpload.sh $ENVIRONMENT
 [ -e "${FLOW}.zip" ] && rm ${FLOW}.zip
 zip -r ${FLOW}.zip $FLOW
-# Restore metadata.json from backup
-[ -f "${FLOW}/metadata.json.bak" ] && mv "${FLOW}/metadata.json.bak" "${FLOW}/metadata.json"
 if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
@@ -70,5 +68,6 @@ then
 else
   cat uploadRecipeResponse.txt
 fi
+[ -f "${FLOW}/metadata.json.bak" ] && mv "${FLOW}/metadata.json.bak" "${FLOW}/metadata.json"
 [ -e uploadRecipeResponse.txt ] && rm uploadRecipeResponse.txt
 rm ${FLOW}.zip


### PR DESCRIPTION
Summary of changes:
1) Insert min/max versions in metadata before recipe upload
2) Fix version number not being inserted into recipe id (potentially only occuring on BSD/OSX machines)
3) Implement temporary file backup to avoid persistent local file modification 