### PR TITLE
REC-1292: inject min/max version on dev-server metarecipe uploads

### DIFF
--- a/uploadMetarecipe.sh
+++ b/uploadMetarecipe.sh
@@ -24,7 +24,12 @@ upsert_json() {
   VALUE="$2"
   FILE="$3"
   tmp=$(mktemp)
-  jq --arg k "$KEY" --arg v "$VALUE" '.[$k] = $v' "$FILE" > "$tmp" && mv "$tmp" "$FILE"
+  if jq --arg k "$KEY" --arg v "$VALUE" '.[$k] = $v' "$FILE" > "$tmp"; then
+    mv "$tmp" "$FILE"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
 }
 
 CHILD_RECIPES=$(jq -r '.bindings | .. | select(type == "object" and has("recipeId") and .variableType == "recipeExecution") | .recipeId | sub("(_[0-9]+){3}$"; "")' $METARECIPE/metadata.json)
@@ -59,9 +64,12 @@ else
       case "$ENVIRONMENT" in
         amanda|testing-manual)
           if [ -f "${STAGING}/${i}/metadata.json" ]; then
-            upsert_json "minVersion" "1.0.0" "${STAGING}/${i}/metadata.json"
-            upsert_json "maxVersion" "100.0.0" "${STAGING}/${i}/metadata.json"
-            echo "Set minVersion to 1.0.0 and maxVersion to 100.0.0 in the uploaded ${i}/metadata.json because you are uploading to a recipe development server (${ENVIRONMENT}). Your local copy is left unchanged."
+            if upsert_json "minVersion" "1.0.0" "${STAGING}/${i}/metadata.json" \
+              && upsert_json "maxVersion" "100.0.0" "${STAGING}/${i}/metadata.json"; then
+              echo "Set minVersion to 1.0.0 and maxVersion to 100.0.0 in the uploaded ${i}/metadata.json because you are uploading to a recipe development server (${ENVIRONMENT}). Your local copy is left unchanged."
+            else
+              echo "Warning: could not set minVersion/maxVersion in ${i}/metadata.json (invalid JSON?). Uploading it unmodified."
+            fi
           fi
           ;;
       esac

--- a/uploadMetarecipe.sh
+++ b/uploadMetarecipe.sh
@@ -14,7 +14,18 @@ case $# in
     echo "not enough arguments supplied.  You must supply the recipeDirectory to this command."
     return 1
     ;;
-esac    
+esac
+
+# update or insert a top-level string-valued key in a JSON file. jq is already a
+# hard dependency of this script (it derives CHILD_RECIPES below), so use it
+# directly rather than carrying uploadRecipe.sh's python3/awk fallbacks.
+upsert_json() {
+  KEY="$1"
+  VALUE="$2"
+  FILE="$3"
+  tmp=$(mktemp)
+  jq --arg k "$KEY" --arg v "$VALUE" '.[$k] = $v' "$FILE" > "$tmp" && mv "$tmp" "$FILE"
+}
 
 CHILD_RECIPES=$(jq -r '.bindings | .. | select(type == "object" and has("recipeId") and .variableType == "recipeExecution") | .recipeId | sub("(_[0-9]+){3}$"; "")' $METARECIPE/metadata.json)
 
@@ -35,8 +46,30 @@ else
     for i in $METARECIPE $CHILD_RECIPES; do
       echo $i
       #based on uploadRecipe.sh
+      # Build a throwaway, uploadable copy of this recipe. Every transform below
+      # runs against the staged copy, so the uploaded artifact can differ from
+      # disk without ever modifying your local working tree.
+      STAGING=$(mktemp -d)
+      mkdir -p "${STAGING}/$(dirname "$i")"
+      cp -R "$i" "${STAGING}/${i}"
+
+      # When uploading to a recipe development server, widen the version
+      # compatibility range so every recipe (parent and children) is always
+      # selectable there. Edits the staged copy only.
+      case "$ENVIRONMENT" in
+        amanda|testing-manual)
+          if [ -f "${STAGING}/${i}/metadata.json" ]; then
+            upsert_json "minVersion" "1.0.0" "${STAGING}/${i}/metadata.json"
+            upsert_json "maxVersion" "100.0.0" "${STAGING}/${i}/metadata.json"
+            echo "Set minVersion to 1.0.0 and maxVersion to 100.0.0 in the uploaded ${i}/metadata.json because you are uploading to a recipe development server (${ENVIRONMENT}). Your local copy is left unchanged."
+          fi
+          ;;
+      esac
+
       [ -e "${i}.zip" ] && rm ${i}.zip
-      zip -r ${i}.zip $i
+      # Zip the staged copy, preserving the same archive layout as `zip -r ${i}.zip $i`.
+      ( cd "$STAGING" && zip -r "${STAGING}/upload.zip" "$i" )
+      mv "${STAGING}/upload.zip" "${i}.zip"
       http_response=$(curl $CURL_ARGS -s -o ${i}.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${i}" "$HOST/ihub-viewer/repository/recipes" --data-binary "@${i}.zip")
       if [ $http_response != "200" ];
       then
@@ -50,6 +83,8 @@ else
         fi
         cat ${i}.txt
         rm ${i}.txt
+        [ -e ${i}.zip ] && rm ${i}.zip
+        rm -rf "$STAGING"
         ERRORS_FOUND=true
         break
       else
@@ -63,6 +98,7 @@ else
         RESPONSES+=$(< ${i}.txt)
         [ -e ${i}.txt ] && rm ${i}.txt
         rm ${i}.zip
+        rm -rf "$STAGING"
       fi
     done
     if [ "$ERRORS_FOUND" = false ]; then


### PR DESCRIPTION
## What

Ports `uploadRecipe.sh`'s dev-server min/max version injection to `uploadMetarecipe.sh` (REC-1292), with the same local-purity guarantee it depends on.

On uploads to a recipe development server (`amanda` / `testing-manual`), every recipe in the upload — the parent metarecipe **and** each child recipe — gets `minVersion=1.0.0` / `maxVersion=100.0.0` injected so it's always version-selectable there.

## How

- Added a jq-based `upsert_json` helper. `jq` is already a hard dependency of this script (it derives `CHILD_RECIPES`), so no python3/awk fallback is carried.
- Inside the upload loop, each recipe is copied to a `mktemp -d` staging dir; the version widening and zip run against the staged copy, never the local working tree.
- If the upsert fails (for example a malformed child `metadata.json`), the script prints a warning and uploads that recipe unmodified. The success message only prints when the widening actually happened.
- The zip preserves the original archive layout (`cd "$STAGING" && zip -r … "$i"`).
- Staging is cleaned up on both the success and error-`break` paths; the error path now also removes its leftover `.zip`.

Non-dev environments (`local`, etc.) are unchanged — no injection.

## Scope

Min/max injection + staging only. The ID version-suffixing from `uploadRecipe.sh` was intentionally left out.

## Verification

- `bash -n` clean.
- Harness run against a fabricated parent + child, with a curl shim capturing the uploaded zips:
  - dev-server upload: widened versions in both uploaded `metadata.json` files, preserved zip archive layout, byte-identical local files after the run, no stray `.zip`/`.txt` left behind
  - malformed child `metadata.json`: warning printed, child uploaded unmodified, parent still widened, local files untouched
  - `local` upload: no injection, uploaded files byte-identical to disk
