### PR TITLE
Allow a configurable credentials directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you're on windows, you may also need to add a zip command to your bash interp
 
 You should execute these scripts from the root of the ihub-partner-? repos
 
-These scripts require that you create a creds folder (by default, in ~/creds - please remember that this will hold credentials, so put it in a safe place. If you override the location of the creds directory, please modify setEnvForUpload.sh to change the **$CREDS_DIR** location), which contains filesets for each of the flow servers you want to interact with:
+These scripts require that you create a creds folder (by default, in `~/creds` - please remember that this will hold credentials, so put it in a safe place). Set `IHUB_CREDS_DIR` to override that location without modifying the scripts. The folder contains filesets for each of the flow servers you want to interact with:
 
 ### **$ALIAS**.token
 

--- a/flowTokens.sh
+++ b/flowTokens.sh
@@ -23,7 +23,7 @@ function usage() {
 [ "$#" -ne "0" ] || usage
 
 command=$1
-creds_dir=$HOME/creds
+creds_dir="${IHUB_CREDS_DIR:-"$HOME/creds"}"
 
 case $command in
 

--- a/setEnvForUpload.sh
+++ b/setEnvForUpload.sh
@@ -2,7 +2,7 @@
 
 ENVIRONMENT=$1
 
-CREDS_DIR=~/creds
+CREDS_DIR="${IHUB_CREDS_DIR:-"$HOME/creds"}"
 
 CURL_ARGS="$CURL_ARGS"
 
@@ -17,32 +17,33 @@ esac
 
 API_HOST="https://api.$ENVIRONMENT.ucroo.org"
 HOST="https://flow.$ENVIRONMENT.ucroo.org"
-CURL_LOC=$CREDS_DIR/$ENVIRONMENT.curl
-FLOW_LOC=$CREDS_DIR/$ENVIRONMENT.flow
-API_LOC=$CREDS_DIR/$ENVIRONMENT.api
-FLOW_TOKEN_LOC=$CREDS_DIR/$ENVIRONMENT.token
+CURL_LOC="$CREDS_DIR/$ENVIRONMENT.curl"
+FLOW_LOC="$CREDS_DIR/$ENVIRONMENT.flow"
+API_LOC="$CREDS_DIR/$ENVIRONMENT.api"
+FLOW_TOKEN_LOC="$CREDS_DIR/$ENVIRONMENT.token"
 
-if [ -f $CURL_LOC ]
+if [ -f "$CURL_LOC" ]
 then
 	echo "overriding curl"
-	CURL_ARGS="$CURL_ARGS $(cat $CURL_LOC)"
+	CURL_ARGS="$CURL_ARGS $(cat "$CURL_LOC")"
 fi
 
-if [ -f $API_LOC ]
+if [ -f "$API_LOC" ]
 then
 	echo "overriding api"
-	API_HOST="$(cat $API_LOC)"
+	API_HOST="$(cat "$API_LOC")"
 fi
 
-if [ -f $FLOW_LOC ]
+if [ -f "$FLOW_LOC" ]
 then
 	echo "overriding flow"
-	HOST="$(cat $FLOW_LOC)"
+	HOST="$(cat "$FLOW_LOC")"
 fi
 
-if [ -f $FLOW_TOKEN_LOC ]
+if [ -f "$FLOW_TOKEN_LOC" ]
 then
-	export FLOW_TOKEN=$(cat $FLOW_TOKEN_LOC)
+	export FLOW_TOKEN
+	FLOW_TOKEN=$(cat "$FLOW_TOKEN_LOC")
 	echo "using token" 
 else
 	echo "no available flow token.  You must have a $CREDS_DIR/$ENVIRONMENT.token file populated with an active flow access token from the server."

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 FLOW="$1"
 ENVIRONMENT="$2"
 case $# in
@@ -10,7 +12,7 @@ case $# in
     ;;
   *)
     echo "not enough arguments supplied.  You must supply the recipeDirectory to this command."
-    return 1
+    exit 1
     ;;
 esac
 
@@ -108,7 +110,7 @@ case "$ENVIRONMENT" in
     ;;
 esac
 
-source setEnvForUpload.sh $ENVIRONMENT
+source "$SCRIPT_DIR/setEnvForUpload.sh" "$ENVIRONMENT"
 [ -e "${FLOW}.zip" ] && rm ${FLOW}.zip
 # Zip the staged copy, preserving the same archive layout as `zip -r ${FLOW}.zip $FLOW`.
 ( cd "$STAGING" && zip -r "${STAGING}/upload.zip" "$FLOW" )
@@ -116,7 +118,7 @@ mv "${STAGING}/upload.zip" "${FLOW}.zip"
 if [ -z $FLOW_TOKEN ] ;
 then
 	rm -rf "$STAGING"
-	return 1
+	exit 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadRecipeResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${FLOW}" "$HOST/ihub-viewer/repository/recipes" --data-binary "@${FLOW}.zip")
 fi


### PR DESCRIPTION
This adds an `IHUB_CREDS_DIR` environment variable for choosing where the developer scripts load Flow credentials. Existing installations continue to use `~/creds` by default.

It also makes `uploadRecipe.sh` use its Bash execution contract and resolve `setEnvForUpload.sh` from the script directory, so loading its sibling helper does not depend on the caller's working directory.

- Apply the configured directory to upload and token-management scripts.
- Quote credential paths when loading environment-specific files.
- Run `uploadRecipe.sh` under Bash and exit cleanly on invalid invocations.
- Resolve shared upload environment setup relative to `uploadRecipe.sh`.
