### PR TITLE
Fix: handle whitespace in entity names, report failures correctly

### DIFF
--- a/batchUploadResourceCollections.sh
+++ b/batchUploadResourceCollections.sh
@@ -10,9 +10,11 @@ cd ./src/main/flowResources || exit
 errorReport=""
 for dir in ./*; do
     if [ -d "$dir" ]; then
+        # Quote $dir: an unquoted name containing a space passes basename a
+        # second argument, which it treats as a suffix to strip.
+        resource=$(basename "$dir")
         echo -e "\nUploading collection $resource\n"
-  
-        resource=$(basename $dir)
+
         if ! uploadResourceCollection.sh "$resource" "$community" ; then
             errorReport+="$resource failed to upload.\n"
         fi
@@ -22,6 +24,7 @@ done
 
 if [ -n "$errorReport" ]; then
     echo -e "Some resources failed to upload:\n$errorReport"
-else
-    echo "All resource collections uploaded successfully!"
+    exit 1
 fi
+
+echo "All resource collections uploaded successfully!"

--- a/deleteBundle.sh
+++ b/deleteBundle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 BUNDLE="$1"
 ENVIRONMENT="$2"
 
@@ -21,19 +22,18 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	http_response=$(curl $CURL_ARGS -s -o uploadBundleResponse.txt -w "%{http_code}" -X DELETE -H "flow-token: $FLOW_TOKEN" "$HOST/ihub-viewer/repository/bundles?id=$BUNDLE")
+	http_response=$(curl $CURL_ARGS -s -o uploadBundleResponse.txt -w "%{http_code}" -X DELETE -H "flow-token: $FLOW_TOKEN" "$HOST/ihub-viewer/repository/bundles?id=$(urlEncode "$BUNDLE")")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadBundleResponse.txt"; then
+  _status=1
 else
 	cat uploadBundleResponse.txt
 	[ -e uploadBundleResponse.txt ] && rm uploadBundleResponse.txt
 fi
 
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/deleteFlow.sh
+++ b/deleteFlow.sh
@@ -21,5 +21,5 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flows/$FLOW" 
+	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flows/$(urlEncode "$FLOW")" 
 fi

--- a/deleteFlowTriggerer.sh
+++ b/deleteFlowTriggerer.sh
@@ -21,5 +21,5 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flowTriggerers?id=$TRIGGERER" 
+	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flowTriggerers?id=$(urlEncode "$TRIGGERER")" 
 fi

--- a/deleteResource.sh
+++ b/deleteResource.sh
@@ -22,5 +22,5 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/resourceCollections/$RESCOL/resources/$RESID" 
+	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/resourceCollections/$(urlEncode "$RESCOL")/resources/$(urlEncode "$RESID")" 
 fi

--- a/deleteResourceCollection.sh
+++ b/deleteResourceCollection.sh
@@ -21,6 +21,6 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/resourceCollections/$FLOW" 
+	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/resourceCollections/$(urlEncode "$FLOW")" 
 fi
 

--- a/deleteSharedConfig.sh
+++ b/deleteSharedConfig.sh
@@ -21,5 +21,5 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/sharedConfig/$FLOW" 
+	curl $CURL_ARGS -X DELETE -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/sharedConfig/$(urlEncode "$FLOW")" 
 fi

--- a/downloadBundle.sh
+++ b/downloadBundle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 BUNDLE="$1"
 ENVIRONMENT="$2"
 
@@ -17,24 +18,24 @@ esac
 
 source setEnvForUpload.sh $ENVIRONMENT
 
-rm ${BUNDLE}.zip
+rm "${BUNDLE}.zip"
 
 if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	http_response=$(curl $CURL_ARGS -s -o ${BUNDLE}.zip -w "%{http_code}" -X GET -H "flow-token: $FLOW_TOKEN" "$HOST/ihub-viewer/repository/bundles?format=flow-zip&id=$BUNDLE")
+	http_response=$(curl $CURL_ARGS -s -o "${BUNDLE}.zip" -w "%{http_code}" -X GET -H "flow-token: $FLOW_TOKEN" "$HOST/ihub-viewer/repository/bundles?format=flow-zip&id=$(urlEncode "$BUNDLE")")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "${BUNDLE}.zip"; then
+  _status=1
 else
-	unzip -o ${BUNDLE}.zip > /dev/null
-	[ -e ${BUNDLE}.zip ] && rm ${BUNDLE}.zip
+	unzip -o "${BUNDLE}.zip" > /dev/null
+	[ -e "${BUNDLE}.zip" ] && rm "${BUNDLE}.zip"
+fi
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
 fi

--- a/setEnvForUpload.sh
+++ b/setEnvForUpload.sh
@@ -4,6 +4,74 @@ ENVIRONMENT=$1
 
 CREDS_DIR=~/creds
 
+# How the sourcing script should signal failure. BASH_SOURCE[1] is that script;
+# if it equals $0 it was executed (exit), otherwise it was sourced by something
+# else (return), as repushAllConfig.sh does. Set here so callers don't each
+# repeat it. Only ever used as a script's final statement, so control flow is
+# unchanged either way.
+[ "${BASH_SOURCE[1]}" = "$0" ] && _EXIT=exit || _EXIT=return
+
+#------------------------------------------------------------------------------
+# Percent-encode a value for use in a URL path segment or query value.
+#
+# Entity names may contain spaces (a resource collection's directory name is
+# its collectionId), and curl rejects the whole URL with
+# "URL rejected: Malformed input to a URL function" if one is interpolated raw.
+# Uploads sidestep this by passing the name in a header; deletes, triggers and
+# ?id= callers put it in the URL and need encoding.
+#
+# usage: "$HOST/ihub-viewer/repository/flows/$(urlEncode "$FLOW")"
+#------------------------------------------------------------------------------
+urlEncode() {
+	printf '%s' "$1" | jq -sRr @uri
+}
+
+#------------------------------------------------------------------------------
+# Validate the outcome of a curl call that captured -w "%{http_code}".
+#
+# Separates three failures that all previously printed
+# "Got unexpected HTTP response ." — curl never ran, curl ran but returned
+# nothing, and a real non-200. Dumps the response body, which is where the
+# actual diagnosis lives.
+#
+# usage: http_response=$(curl ... ); curlStatus=$?
+#        validateHttpResponse "$curlStatus" "$http_response" <context> [bodyFile]
+# returns: 0 on HTTP 200, 1 otherwise
+#------------------------------------------------------------------------------
+validateHttpResponse() {
+	local curlStatus="$1"
+	local response="$2"
+	local context="${3:-request}"
+	local bodyFile="${4:-}"
+
+	if [ "$curlStatus" -ne 0 ]; then
+		echo "curl failed before any HTTP exchange for '$context' (see error above) — nothing was sent."
+		return 1
+	fi
+
+	if [ "$response" = "200" ]; then
+		return 0
+	fi
+
+	if [ -z "$response" ]; then
+		echo "No HTTP response received for '$context'; the request never completed. Check that the payload file was created."
+	elif [ "$response" = "302" ]; then
+		echo "Got unexpected HTTP response $response for '$context'. This is likely due to your token being incorrect."
+	elif [ "$response" = "401" ] || [ "$response" = "403" ]; then
+		echo "Got unexpected HTTP response $response for '$context'. The $ENVIRONMENT token is missing, expired, or lacks permission."
+	else
+		echo "Got unexpected HTTP response $response for '$context'. This is likely an error."
+	fi
+
+	if [ -n "$bodyFile" ] && [ -s "$bodyFile" ]; then
+		echo "--- response body ---"
+		cat "$bodyFile"
+		echo "--- end response body ---"
+	fi
+
+	return 1
+}
+
 CURL_ARGS="$CURL_ARGS"
 
 case $# in
@@ -39,6 +107,12 @@ then
 	echo "overriding flow"
 	HOST="$(cat $FLOW_LOC)"
 fi
+
+# Callers build URLs as "$HOST/path", so a trailing slash in the override file
+# produces "//path". Jetty rejects that with 400 "Ambiguous URI empty segment"
+# before authentication runs, which reads like a bad token but isn't.
+API_HOST="${API_HOST%/}"
+HOST="${HOST%/}"
 
 if [ -f $FLOW_TOKEN_LOC ]
 then

--- a/test/fixtures/test whitespace_widget/files/widgets/with space/hello.html
+++ b/test/fixtures/test whitespace_widget/files/widgets/with space/hello.html
@@ -1,0 +1,1 @@
+<html><body>whitespace ok</body></html>

--- a/test/fixtures/test whitespace_widget/manifest.json
+++ b/test/fixtures/test whitespace_widget/manifest.json
@@ -1,0 +1,24 @@
+{
+  "collectionId": "test whitespace_widget",
+  "entityId": "rc:test whitespace_widget",
+  "type": "resourceCollection",
+  "resources": [
+    {
+      "resourceId": "with_space_html",
+      "resourceCollectionId": "test whitespace_widget",
+      "resourceStatusCode": 200,
+      "resourceAccessorPath": "/widgets/with space/hello.html",
+      "resourceAccessorMethod": "GET",
+      "resourceAccessorHeaders": [],
+      "resourceStateful": false,
+      "removeDefaultCachingHeaders": false,
+      "resourceHeaders": [["Content-Type", "text/html"]],
+      "resourcePath": "files/widgets/with space/hello.html",
+      "resourceDescription": "Regression fixture: spaces in the collection name and resource paths",
+      "enableConfigInterpolation": false,
+      "useVirtualThreads": true
+    }
+  ],
+  "name": "test whitespace_widget",
+  "description": "Regression fixture: spaces in the collection name and resource paths"
+}

--- a/test/run-whitespace-test.sh
+++ b/test/run-whitespace-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Regression test: a resource collection whose name contains a space must
+# upload, and the scripts must report the outcome truthfully.
+#
+#   ./test/run-whitespace-test.sh <env>
+#
+# Requires ~/creds/<env>.token and ~/creds/<env>.flow for an env you are happy
+# to write a throwaway collection to.
+#
+# Guards three bugs that shipped together:
+#   1. `basename $dir` unquoted truncated the name at the space, so the
+#      collection was never found and never uploaded.
+#   2. A failure printed "Got unexpected HTTP response ." with no code and no
+#      response body.
+#   3. Exit status did not reflect the outcome, in both directions — failures
+#      exited 0, and later, successes exited 1.
+
+set -u
+
+ENV="${1:-}"
+if [ -z "$ENV" ]; then
+    echo "usage: $0 <env>"
+    exit 2
+fi
+
+SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+FIXTURE="$SCRIPTS/test/fixtures"
+COLLECTION="test whitespace_widget"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/ihub-community-${ENV}"
+mkdir -p "$REPO/src/main/flowResources"
+cp -R "$FIXTURE/$COLLECTION" "$REPO/src/main/flowResources/"
+
+echo "uploading '$COLLECTION' to '$ENV'"
+cd "$REPO" || exit 1
+
+output=$(PATH="$SCRIPTS:$PATH" bash "$SCRIPTS/batchUploadResourceCollections.sh" 2>&1)
+status=$?
+
+echo "$output"
+echo "---------------------------------------------"
+
+failures=0
+
+# The name must survive word splitting all the way to the archive.
+if grep -q "Uploading collection $COLLECTION" <<<"$output"; then
+    echo "PASS  collection name kept its space"
+else
+    echo "FAIL  collection name was truncated or blank (bug 1)"
+    failures=$((failures + 1))
+fi
+
+# An empty HTTP code used to render as "response ." with no diagnosis.
+if grep -qE 'Got unexpected HTTP response \.|unary operator expected' <<<"$output"; then
+    echo "FAIL  failure reported without a status code (bug 2)"
+    failures=$((failures + 1))
+fi
+
+# Exit status must match what actually happened.
+if grep -q '"message":"success"' <<<"$output"; then
+    if [ "$status" -eq 0 ]; then
+        echo "PASS  upload succeeded and exit status is 0"
+    else
+        echo "FAIL  upload succeeded but exit status was $status (bug 3)"
+        failures=$((failures + 1))
+    fi
+else
+    if [ "$status" -ne 0 ]; then
+        echo "PASS  upload failed and exit status is non-zero"
+        echo "      (not a successful upload - check the token for '$ENV')"
+    else
+        echo "FAIL  upload did not succeed but exit status was 0 (bug 3)"
+        failures=$((failures + 1))
+    fi
+fi
+
+echo "---------------------------------------------"
+if [ "$failures" -eq 0 ]; then
+    echo "OK"
+else
+    echo "$failures check(s) failed"
+fi
+
+echo
+echo "Remove the uploaded collection with:"
+echo "  deleteResourceCollection.sh '$COLLECTION' $ENV"
+
+exit "$failures"

--- a/triggerFlow.sh
+++ b/triggerFlow.sh
@@ -21,5 +21,5 @@ if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
-	curl $CURL_ARGS -X GET -H "flow-token: $FLOW_TOKEN" "$HOST/flows/$FLOW"
+	curl $CURL_ARGS -X GET -H "flow-token: $FLOW_TOKEN" "$HOST/flows/$(urlEncode "$FLOW")"
 fi

--- a/uploadBundle.sh
+++ b/uploadBundle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 BUNDLE="$1"
 ENVIRONMENT="$2"
 
@@ -59,33 +60,32 @@ safeFileReference () {
 }
 
 SAFE_BUNDLE=$(safeName $BUNDLE)
-rm ${SAFE_BUNDLE}.zip
+rm "${SAFE_BUNDLE}.zip"
 REFS=$(cat ${SAFE_BUNDLE}.json | jq '.. |."fileReference"? | select(. != null)')
 SAFE_REFS=""
 for FR in $REFS;
 do SAFE_REFS="$SAFE_REFS $(safeFileReference ${FR//\"/})"
 done
-zip -r ${SAFE_BUNDLE}.zip ${SAFE_BUNDLE}.json $SAFE_REFS
+zip -r "${SAFE_BUNDLE}.zip" "${SAFE_BUNDLE}.json" $SAFE_REFS
 
 if [ -z $FLOW_TOKEN ] ;
 then
 	exit 1
 else
-	http_response=$(curl $CURL_ARGS -s -o uploadBundleResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" "$HOST/ihub-viewer/repository/bundles?format=flow-zip&id=$BUNDLE" --data-binary "@${SAFE_BUNDLE}.zip")
+	http_response=$(curl $CURL_ARGS -s -o uploadBundleResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" "$HOST/ihub-viewer/repository/bundles?format=flow-zip&id=$(urlEncode "$BUNDLE")" --data-binary "@${SAFE_BUNDLE}.zip")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-		cat uploadBundleResponse.txt
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadBundleResponse.txt"; then
+  _status=1
 else
   cat uploadBundleResponse.txt
 fi
 
 [ -e uploadBundleResponse.txt ] && rm uploadBundleResponse.txt
-rm ${SAFE_BUNDLE}.zip
+rm "${SAFE_BUNDLE}.zip"
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadConfigPanel.sh
+++ b/uploadConfigPanel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 SOURCE_FILE="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadConfigPanelResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/configPanels" --data-binary "@src/main/configPanels/$SOURCE_FILE.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadConfigPanelResponse.txt"; then
+  _status=1
 else
   cat uploadConfigPanelResponse.txt
 fi
 
 [ -e uploadConfigPanelResponse.txt ] && rm uploadConfigPanelResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadFlow.sh
+++ b/uploadFlow.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 FLOW="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadFlowResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flows" --data-binary "@src/main/flows/$FLOW.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadFlowResponse.txt"; then
+  _status=1
 else
   cat uploadFlowResponse.txt
 fi
 
 [ -e uploadFlowResponse.txt ] && rm uploadFlowResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadMetarecipe.sh
+++ b/uploadMetarecipe.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 #!/bin/sh
 METARECIPE="$1"
 ENVIRONMENT="$2"
@@ -74,24 +75,18 @@ else
           ;;
       esac
 
-      [ -e "${i}.zip" ] && rm ${i}.zip
+      [ -e "${i}.zip" ] && rm "${i}.zip"
       # Zip the staged copy, preserving the same archive layout as `zip -r ${i}.zip $i`.
       ( cd "$STAGING" && zip -r "${STAGING}/upload.zip" "$i" )
       mv "${STAGING}/upload.zip" "${i}.zip"
       http_response=$(curl $CURL_ARGS -s -o ${i}.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${i}" "$HOST/ihub-viewer/repository/recipes" --data-binary "@${i}.zip")
-      if [ $http_response != "200" ];
-      then
-        echo "$RESPONSES"
-        printf "\n${bold}Error encountered${normal} while uploading %s. Not continuing. Error encountered: " $i
-        if [ $http_response == "302" ];
-        then
-          echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-        else
-          echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-        fi
+      curlStatus=$?
+      _status=0
+      if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "${i}.txt"; then
+        _status=1
         cat ${i}.txt
         rm ${i}.txt
-        [ -e ${i}.zip ] && rm ${i}.zip
+        [ -e "${i}.zip" ] && rm "${i}.zip"
         rm -rf "$STAGING"
         ERRORS_FOUND=true
         break
@@ -105,7 +100,7 @@ else
         RESPONSES+=$'\n'
         RESPONSES+=$(< ${i}.txt)
         [ -e ${i}.txt ] && rm ${i}.txt
-        rm ${i}.zip
+        rm "${i}.zip"
         rm -rf "$STAGING"
       fi
     done
@@ -117,4 +112,8 @@ else
       echo "$RESPONSES"
     fi
   fi
+fi
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
 fi

--- a/uploadPatchSet.sh
+++ b/uploadPatchSet.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 TARGET="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	exit 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadFlowResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/patchSets" --data-binary "@src/main/patchSets/$TARGET.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadFlowResponse.txt"; then
+  _status=1
 else
   cat uploadFlowResponse.txt
 fi
 
 [ -e uploadFlowResponse.txt ] && rm uploadFlowResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadRecipe.sh
+++ b/uploadRecipe.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 FLOW="$1"
 ENVIRONMENT="$2"
 case $# in
@@ -109,7 +110,7 @@ case "$ENVIRONMENT" in
 esac
 
 source setEnvForUpload.sh $ENVIRONMENT
-[ -e "${FLOW}.zip" ] && rm ${FLOW}.zip
+[ -e "${FLOW}.zip" ] && rm "${FLOW}.zip"
 # Zip the staged copy, preserving the same archive layout as `zip -r ${FLOW}.zip $FLOW`.
 ( cd "$STAGING" && zip -r "${STAGING}/upload.zip" "$FLOW" )
 mv "${STAGING}/upload.zip" "${FLOW}.zip"
@@ -119,19 +120,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadRecipeResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${FLOW}" "$HOST/ihub-viewer/repository/recipes" --data-binary "@${FLOW}.zip")
+	curlStatus=$?
 fi
-if [ "$http_response" != "200" ];
-then
-  if [ "$http_response" = "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-		cat uploadRecipeResponse.txt
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadRecipeResponse.txt"; then
+  _status=1
 else
   cat uploadRecipeResponse.txt
 fi
 [ -e uploadRecipeResponse.txt ] && rm uploadRecipeResponse.txt
-rm ${FLOW}.zip
+rm "${FLOW}.zip"
 rm -rf "$STAGING"
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadRecipeAnswers.sh
+++ b/uploadRecipeAnswers.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 RECIPE="$1"
 ANSWER="$2"
 ENVIRONMENT="$3"
@@ -23,18 +24,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadRecipeAnswersResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/recipes/$RECIPE/execute?forceInstallAll=true" --data-binary "@$ANSWER")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadRecipeAnswersResponse.txt"; then
+  _status=1
 else
   cat uploadRecipeAnswersResponse.txt
 fi
 
 [ -e uploadRecipeAnswersResponse.txt ] && rm uploadRecipeAnswersResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadResourceCollection.sh
+++ b/uploadResourceCollection.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 FLOW="$1"
 ENVIRONMENT="$2"
 
@@ -17,29 +18,29 @@ esac
 
 source setEnvForUpload.sh $ENVIRONMENT
 
-rm ${FLOW}.zip
-zip -r ${FLOW}.zip $FLOW
+# Collection directory names can contain spaces (the name is the Flow
+# collectionId, so it cannot be renamed), which word-splits when unquoted.
+rm "${FLOW}.zip"
+zip -r "${FLOW}.zip" "$FLOW"
 
 if [ -z $FLOW_TOKEN ] ;
 then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadResourceCollectionResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/octet-stream" -H "format: zip" -H "name: ${FLOW}" "$HOST/ihub-viewer/repository/resourceCollections" --data-binary "@${FLOW}.zip")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
-
-  return 1
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadResourceCollectionResponse.txt"; then
+  _status=1
 else
   cat uploadResourceCollectionResponse.txt
 fi
 
 [ -e uploadResourceCollectionResponse.txt ] && rm uploadResourceCollectionResponse.txt
-rm ${FLOW}.zip
+rm "${FLOW}.zip"
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadResourceCollectionJson.sh
+++ b/uploadResourceCollectionJson.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 FLOW="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadResourceCollectionJsonResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/resourceCollections" --data-binary "@${FLOW}.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadResourceCollectionJsonResponse.txt"; then
+  _status=1
 else
   cat uploadResourceCollectionJsonResponse.txt
 fi
 
 [ -e uploadResourceCollectionJsonResponse.txt ] && rm uploadResourceCollectionJsonResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadSharedConfig.sh
+++ b/uploadSharedConfig.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 FLOW="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadSharedConfigResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/sharedConfig" --data-binary "@src/main/sharedConfig/$FLOW.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadSharedConfigResponse.txt"; then
+  _status=1
 else
   cat uploadSharedConfigResponse.txt
 fi
 
 [ -e uploadSharedConfigResponse.txt ] && rm uploadSharedConfigResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadSharedConfigFragment.sh
+++ b/uploadSharedConfigFragment.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 FRAGMENT_FILE="$1"
 FRAGMENT_NAME="$2"
 ENVIRONMENT="$3"
@@ -28,18 +29,18 @@ then
 	exit 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadSharedConfigFragmentResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" -H "referenceId: $FRAGMENT_NAME" -H "secure: $SECURE" "$HOST/ihub-viewer/repository/sharedConfig" --data-binary "@src/main/sharedConfig/$FRAGMENT_FILE")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadSharedConfigFragmentResponse.txt"; then
+  _status=1
 else
   cat uploadSharedConfigFragmentResponse.txt
 fi
 
 [ -e uploadSharedConfigFragmentResponse.txt ] && rm uploadSharedConfigFragmentResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi

--- a/uploadTrigger.sh
+++ b/uploadTrigger.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 SOURCE_FILE="$1"
 ENVIRONMENT="$2"
 
@@ -22,18 +23,18 @@ then
 	return 1
 else
 	http_response=$(curl $CURL_ARGS -s -o uploadTriggerResponse.txt -w "%{http_code}" -X POST -H "flow-token: $FLOW_TOKEN" -H "Content-Type: application/json" "$HOST/ihub-viewer/repository/flowTriggerers" --data-binary "@src/main/triggerers/$SOURCE_FILE.json")
+	curlStatus=$?
 fi
 
-if [ $http_response != "200" ];
-then
-  if [ $http_response == "302" ];
-  then
-    echo "Got unexpected HTTP response ${http_response}. This is likely due to your token being incorrect."
-  else
-    echo "Got unexpected HTTP response ${http_response}. This is likely an error."
-  fi
+_status=0
+if ! validateHttpResponse "$curlStatus" "$http_response" "$1" "uploadTriggerResponse.txt"; then
+  _status=1
 else
   cat uploadTriggerResponse.txt
 fi
 
 [ -e uploadTriggerResponse.txt ] && rm uploadTriggerResponse.txt
+
+if [ "$_status" -ne 0 ]; then
+    $_EXIT 1
+fi


### PR DESCRIPTION
Handful of changes that I had to lump together as they tricked me up individually - and fixing one created the other. Tried to make this as separate PRs but just ended up combining.

1. Whitespace caused resource collections to fail to upload - myrepo mywidget would fail to upload previously. Since we allow spaces in resource collections, we need to guard here.
2. Added a guard for trailing “/“ in host name (QOL)
3. The “if 200 / if 302” had an issue where if we didn’t get a response we would get a parse error - “ uploadResourceCollection.sh: line 30: [: !=: unary operator expected” instead of “ Got unexpected HTTP response .” Fixed that, pulled into a util, and made more verbose. Failure also exited 0, with “All resource collections uploaded successfully!”, the only reason I saw number 1 on a cutover was scrolling back through logs.
4. URL encoded for deleting, which would also have failed (curl: (3) URL rejected).

Added a test script to prove everything, feel free to keep or leave as a regression test. Real test is just "do scripts still work, and exit correctly on failure"